### PR TITLE
Fix director credentials extraction

### DIFF
--- a/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
+++ b/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
@@ -122,7 +122,7 @@ end
 
 def bosh_manifest
   begin
-    YAML.load_file("old_bosh_data/BOSH_DIRECTOR_DATA.json")['manifest']
+    YAML.load_file("bosh_data/BOSH_DIRECTOR_DATA.json")['manifest']
   rescue JSON::ParserError => e
     raise "BOSHDirector:BadManifestFile:#{e}"
   end

--- a/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
+++ b/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
@@ -156,7 +156,7 @@ def target_bosh_director(logger)
   username, password = director_credentials
   target_cmd = "-n --ca-cert #{ENV['BOSH_ROOT_CERT_PATH']} target #{director_ip}"
   exec_cmd_on_ops_mgr(target_cmd, logger)
-  bosh_login(bosh_cred[0], bosh_cred[1], logger)
+  bosh_login(username, password, logger)
 end
 
 def set_bosh_deployment(deployment_name,logger)

--- a/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
+++ b/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
@@ -240,3 +240,12 @@ end
 if __FILE__ == $PROGRAM_NAME
   go_to_sleep(*ARGV)
 end
+
+
+unless Hash.respond_to?(:dig)
+  class Hash
+    def dig(*keys)
+      keys.reduce(self){|val, key| val && val[key]}
+    end
+  end
+end


### PR DESCRIPTION
We are getting this error with OpsManager 1.7.15:

```
D, [2016-10-18T02:56:58.768499 #5] DEBUG -- : Targetting:BOSHDirector:/tmp/build/ac19200b/aws-frugal-repo/deploy_pcf/aws/aws-frugal/scripts/get_bosh_director_ip.sh pcf.env.london.cf-app.com redacted redacted
/tmp/build/ac19200b/aws-frugal-repo/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb:139:in `target_bosh_director': BOSHDirector:BadDataFile:10.0.16.5 (RuntimeError)
{
  "name": "redacted",
  "password": "redacted",
  "groups": [
    "bosh.admin"
  ]
}
    from /tmp/build/ac19200b/aws-frugal-repo/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb:199:in `go_to_sleep'
    from ./git-tile-pipeline/scripts/control-envs/run.rb:31:in `<main>'
```

After investigation, we found out that the latest versions of OpsManager (both 1.7 and 1.8) expose the director credentials as a JSON object.

This PR makes the script consider both the inline string credentials and the JSON object.

Thanks!