### PR TITLE
Error handling on remote commands

### DIFF
--- a/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
+++ b/deploy_pcf/aws/aws-frugal/scripts/go_to_sleep.rb
@@ -115,7 +115,7 @@ def exec_cmd_on_ops_mgr(cmd, logger, bosh_cmd=true)
   end
   stdout, stderr, status = Open3.capture3(exec_cmd)
   logger.info("Open3:STDOUT:#{stdout}, Open3:STDERR:#{stderr}")
-  if stderr.downcase.include? ("error (exit code 1)") || stdout.downcase.include?("did not complete")
+  if stderr.downcase.include? ("error (exit code 1)") || stdout.downcase.include?("did not complete") || status.exitstatus != 0
      raise "BOSH:CMD:Failed:#{exec_cmd}"
   end
 end


### PR DESCRIPTION
Hey!

We are having green jobs even when the `bosh start/stop` fails. We added a verification on the exit code of the command executed on opsman, so the script can raise an error if the task fails.

Thanks!