### PR TITLE
connect tcp router VMs to the tcp router loadbalancers for SRT deploys

### DIFF
--- a/deploy_pcf/2.7/gcp_cf_resources_srt.json.erb
+++ b/deploy_pcf/2.7/gcp_cf_resources_srt.json.erb
@@ -1,4 +1,5 @@
-<% http_lb=`terraform output http_lb_backend_name`.strip
+<% tcp_router=`terraform output tcp_router_pool`.strip
+ http_lb=`terraform output http_lb_backend_name`.strip
  ws_router=`terraform output ws_router_pool`.strip
  ssh_router=`terraform output ssh_router_pool`.strip %>
 
@@ -13,6 +14,11 @@
     "instances": 1,
     "elb_names": [
       "tcp:<%= ws_router %>"
+    ]
+  },
+  "tcp_router": {
+    "elb_names": [
+      "tcp:<%= tcp_router %>"
     ]
   },
   "control": {

--- a/deploy_pcf/3.0/gcp_cf_resources_srt.json.erb
+++ b/deploy_pcf/3.0/gcp_cf_resources_srt.json.erb
@@ -1,4 +1,5 @@
-<% http_lb=`terraform output http_lb_backend_name`.strip
+<% tcp_router=`terraform output tcp_router_pool`.strip
+ http_lb=`terraform output http_lb_backend_name`.strip
  ws_router=`terraform output ws_router_pool`.strip
  ssh_router=`terraform output ssh_router_pool`.strip %>
 
@@ -13,6 +14,11 @@
     "instances": 1,
     "elb_names": [
       "tcp:<%= ws_router %>"
+    ]
+  },
+  "tcp_router": {
+    "elb_names": [
+      "tcp:<%= tcp_router %>"
     ]
   },
   "control": {


### PR DESCRIPTION
Hook up the tcp loadbalancer created by terraform to the TAS tcp_router VMs when using small footprint environments (the gcp_cf_resources.json.erb already had the right info).